### PR TITLE
add npm(rc) support

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -465,6 +465,17 @@ rules:
         alias: netbeans
         command: netbeans --userdir ${XDG_CONFIG_HOME}/ncmpc/config
 
+  - name: npm
+    dotfile:
+      name: .npmrc
+    actions:
+      - type: migrate
+        source: ${HOME}/.npmrc
+        dest: ${XDG_CONFIG_HOME}/npm/npmrc
+      - type: export
+        key: NPM_CONFIG_USERCONFIG
+        value: ${XDG_CONFIG_HOME}/npm/npmrc
+
   - name: nvidia-settings
     dotfile:
       name: .nvidia-settings-rc


### PR DESCRIPTION
currently this only migrates .npmrc - migrating .npm requires some config vars to be set in .npmrc correctly

see https://github.com/npm/cli/issues/654 for details
