### PR TITLE
Fix migration when dest is on different partition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/adrg/xdg v0.2.3
 	github.com/google/go-cmp v0.5.4
 	github.com/mitchellh/mapstructure v1.4.0
+	github.com/otiai10/copy v1.3.0
 	github.com/spf13/cobra v1.1.1
 	github.com/wzshiming/ctc v1.2.3
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,12 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/otiai10/copy v1.3.0 h1:Z0OIFgj8hyI18YVzgPXpp652vv0NggCGWaNKSPN9KU8=
+github.com/otiai10/copy v1.3.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.2/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/rules/migrate.go
+++ b/internal/rules/migrate.go
@@ -3,17 +3,77 @@ package rules
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/doron-cohen/antidot/internal/tui"
 	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/otiai10/copy"
 )
 
 type Migrate struct {
 	Source  string
 	Dest    string
 	Symlink bool
+}
+
+func MoveDirectory(source, dest string) error {
+	err := copy.Copy(source, dest)
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(source)
+	if err != nil {
+		tui.Warn("Failed to remove original directory: %s", err)
+	}
+
+	return nil
+}
+
+// Adapted from https://gist.github.com/var23rav/23ae5d0d4d830aff886c3c970b8f6c6b
+func MoveFile(source, dest string) error {
+	inputFile, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+
+	outputFile, err := os.Create(dest)
+	if err != nil {
+		inputFile.Close()
+		return err
+	}
+	defer outputFile.Close()
+
+	_, err = io.Copy(outputFile, inputFile)
+	inputFile.Close()
+	if err != nil {
+		return err
+	}
+
+	// The copy was successful, so now delete the original file
+	err = os.Remove(source)
+	if err != nil {
+		tui.Warn("Failed to remove original file: %s", err)
+	}
+
+	return nil
+}
+
+// Try to move file/directory with os.Rename and if that fails, do a copy + delete
+func Move(source, dest string) error {
+	err := os.Rename(source, dest)
+	if err == nil {
+		return nil
+	}
+
+	fi, err := os.Stat(source)
+	if fi.Mode().IsDir() {
+		return MoveDirectory(source, dest)
+	}
+
+	return MoveFile(source, dest)
 }
 
 func (m Migrate) Apply() error {
@@ -37,7 +97,7 @@ func (m Migrate) Apply() error {
 		return err
 	}
 
-	err = os.Rename(source, dest)
+	err = Move(source, dest)
 	if err != nil {
 		return err
 	}

--- a/internal/rules/migrate.go
+++ b/internal/rules/migrate.go
@@ -1,8 +1,6 @@
 package rules
 
 import (
-	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -27,11 +25,8 @@ func (m Migrate) Apply() error {
 	}
 
 	dest := utils.ExpandEnv(m.Dest)
-	if utils.FileExists(dest) {
-		errMessage := fmt.Sprintf("Destination file %s exists", dest)
-		return errors.New(errMessage)
-	}
 
+	// NB: No error is thrown if dir already exists
 	err = os.MkdirAll(filepath.Dir(dest), os.FileMode(0o755))
 	if err != nil {
 		return err

--- a/internal/rules/migrate.go
+++ b/internal/rules/migrate.go
@@ -3,77 +3,17 @@ package rules
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/doron-cohen/antidot/internal/tui"
 	"github.com/doron-cohen/antidot/internal/utils"
-	"github.com/otiai10/copy"
 )
 
 type Migrate struct {
 	Source  string
 	Dest    string
 	Symlink bool
-}
-
-func MoveDirectory(source, dest string) error {
-	err := copy.Copy(source, dest)
-	if err != nil {
-		return err
-	}
-
-	err = os.RemoveAll(source)
-	if err != nil {
-		tui.Warn("Failed to remove original directory: %s", err)
-	}
-
-	return nil
-}
-
-// Adapted from https://gist.github.com/var23rav/23ae5d0d4d830aff886c3c970b8f6c6b
-func MoveFile(source, dest string) error {
-	inputFile, err := os.Open(source)
-	if err != nil {
-		return err
-	}
-
-	outputFile, err := os.Create(dest)
-	if err != nil {
-		inputFile.Close()
-		return err
-	}
-	defer outputFile.Close()
-
-	_, err = io.Copy(outputFile, inputFile)
-	inputFile.Close()
-	if err != nil {
-		return err
-	}
-
-	// The copy was successful, so now delete the original file
-	err = os.Remove(source)
-	if err != nil {
-		tui.Warn("Failed to remove original file: %s", err)
-	}
-
-	return nil
-}
-
-// Try to move file/directory with os.Rename and if that fails, do a copy + delete
-func Move(source, dest string) error {
-	err := os.Rename(source, dest)
-	if err == nil {
-		return nil
-	}
-
-	fi, err := os.Stat(source)
-	if fi.Mode().IsDir() {
-		return MoveDirectory(source, dest)
-	}
-
-	return MoveFile(source, dest)
 }
 
 func (m Migrate) Apply() error {
@@ -97,7 +37,7 @@ func (m Migrate) Apply() error {
 		return err
 	}
 
-	err = Move(source, dest)
+	err = utils.MovePath(source, dest)
 	if err != nil {
 		return err
 	}

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/doron-cohen/antidot/internal/tui"
+	"github.com/otiai10/copy"
 )
 
 func FileExists(filename string) bool {
@@ -38,4 +41,33 @@ func MoveFile(sourcePath, destPath string) error {
 		return fmt.Errorf("Failed removing original file: %s", err)
 	}
 	return nil
+}
+
+func MoveDirectory(source, dest string) error {
+	err := copy.Copy(source, dest)
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(source)
+	if err != nil {
+		tui.Warn("Failed to remove original directory: %s", err)
+	}
+
+	return nil
+}
+
+// Try to move file/directory with os.Rename and if that fails, do a copy + delete
+func MovePath(source, dest string) error {
+	err := os.Rename(source, dest)
+	if err == nil {
+		return nil
+	}
+
+	fi, err := os.Stat(source)
+	if fi.Mode().IsDir() {
+		return MoveDirectory(source, dest)
+	}
+
+	return MoveFile(source, dest)
 }

--- a/internal/utils/files_test.go
+++ b/internal/utils/files_test.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPathExists(t *testing.T) {
+	exists, err := PathExists("file_that_doesnt_exist")
+	if exists {
+		t.Fatalf("PathExists() returning true for file which doesn't exist")
+	}
+
+	f, err := os.Create("testfile")
+	if err != nil {
+		t.Fatalf("Error creating test file: %v", err)
+	}
+	f.Close()
+	defer os.Remove("testfile")
+
+	exists, err = PathExists("testfile")
+	if !exists {
+		t.Fatalf("PathExists() returning false for file which exists")
+	}
+
+	os.RemoveAll("testdir") // Make sure it doesn't exist
+	err = os.Mkdir("testdir", 0o755)
+	if err != nil {
+		t.Fatalf("Could not create test directory: %v", err)
+	}
+	defer os.RemoveAll("testdir")
+
+	exists, err = PathExists("testdir")
+	if exists {
+		t.Fatalf("PathExists() returning true for empty directory")
+	}
+
+	f, err = os.Create("testdir/testfile")
+	if err != nil {
+		t.Fatalf("Error creating testdir/testfile")
+	}
+	f.Close()
+
+	exists, err = PathExists("testdir")
+	if !exists {
+		t.Fatalf("PathExists() returning false for non-empty directory")
+	}
+}


### PR DESCRIPTION
This issue affects me as I have my .local folder symlinked to a separate btrfs subvolume (I know this sounds odd, but it's the only way to exclude it from backups created with btrfs snapshots). The code in migrate.go will still attempt to use ``os.Rename()`` first and only then fall back on doing a copy + delete, so this shouldn't affect existing users.

Commit message:
os.Rename will fail if the destination file/folder is on a different
partition from the source. Unfortunately, in this case the only option
is to copy the file or each of the folder's files then delete the
original. Update migrate.go to handle this case correctly.

For the folder-copying case, I have used this library here: https://github.com/otiai10/copy