### PR TITLE
Add support for ccache

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -106,6 +106,19 @@ rules:
         key: CARGO_HOME
         value: ${XDG_DATA_HOME}/cargo
 
+  - name: ccache
+    description: ccache cache dir
+    dotfile:
+      name: .ccache
+      is_dir: true
+    actions:
+      - type: migrate
+        source: ${HOME}/.ccache
+        dest: ${XDG_CACHE_HOME}/ccache
+      - type: export
+        key: CCACHE_DIR
+        value: ${XDG_CACHE_HOME}/ccache
+
   - name: conky
     dotfile:
       name: .conkyrc


### PR DESCRIPTION
ccache's cache dir can be specified with ``CCACHE_DIR``.

Code has been tested with this rule.