### PR TITLE
Add rule for npm cache folder

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -552,6 +552,18 @@ rules:
         alias: netbeans
         command: netbeans --userdir ${XDG_CONFIG_HOME}/ncmpc/config
 
+  - name: npm
+    dotfile:
+      name: .npm
+      is_dir: true
+    actions:
+      - type: migrate
+        source: ${HOME}/.npm
+        dest: ${XDG_CACHE_HOME}/npm
+      - type: export
+        key: npm_config_cache
+        value: ${XDG_CACHE_HOME}/npm
+
   - name: npmrc
     dotfile:
       name: .npmrc

--- a/rules.yaml
+++ b/rules.yaml
@@ -552,7 +552,7 @@ rules:
         alias: netbeans
         command: netbeans --userdir ${XDG_CONFIG_HOME}/ncmpc/config
 
-  - name: npm
+  - name: npmrc
     dotfile:
       name: .npmrc
     actions:


### PR DESCRIPTION
In addition to the ``.npmrc`` user config file (for which there is already a rule), npm also creates a cache folder at ``~/.npm`` by default. Add a rule for this.

As the existing npm rule was already called npm, I renamed it.

Closes #48.