### PR TITLE
Add rule for ~/.gitconfig file

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -235,6 +235,14 @@ rules:
         alias: gdb
         command: gdb -n -x $XDG_CONFIG_HOME/gdb/init
 
+  - name: gitconfig
+    dotfile:
+      name: .gitconfig
+    actions:
+      - type: migrate
+        source: ${HOME}/.gitconfig
+        dest: ${XDG_CONFIG_HOME}/git/config
+
   - name: gnupg
     dotfile:
       name: .gnupg


### PR DESCRIPTION
Git will look for a file at ``$XDG_CONFIG_HOME/git/config`` anyway, so we only need to migrate the existing file.

Closes #86.