### PR TITLE
Ion support

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -40,9 +40,6 @@ var cleanCmd = &cobra.Command{
 
 		utils.ApplyDefaultXdgEnv()
 
-		sh, err := shell.Get(shellOverride)
-		tui.FatalIfError("Failed to detect shell", err)
-
 		dotfiles, err := dotfile.Detect(userHomeDir)
 		tui.FatalIfError("Failed to detect dotfiles in home dir", err)
 		if len(dotfiles) == 0 {
@@ -57,19 +54,6 @@ var cleanCmd = &cobra.Command{
 		actx := rules.ActionContext{KeyValueStore: kvStore}
 
 		appliedRule := false
-		defer func() {
-			if appliedRule {
-				err := shell.DumpAliases(sh, kvStore)
-				if err != nil {
-					tui.Warn("Failed to dump aliases")
-				}
-				err = shell.DumpExports(sh, kvStore)
-				if err != nil {
-					tui.Warn("Failed to dump exports")
-				}
-			}
-		}()
-
 		for _, dotfile := range dotfiles {
 			rule := rules.MatchRule(&dotfile)
 			if rule == nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -9,7 +9,7 @@ import (
 
 func init() {
 	initCmd.Flags().StringVarP(
-		&shellOverride, "shell", "s", "", "What shell to print an init script for - One of: bash zsh fish",
+		&shellOverride, "shell", "s", "", "What shell to print an init script for - One of:" + sh.ListShells(),
 	)
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -9,18 +9,19 @@ import (
 
 func init() {
 	initCmd.Flags().StringVarP(
-		&shellOverride, "shell", "s", "", "Which shell to render the init script to",
+		&shellOverride, "shell", "s", "", "What shell to print an init script for - One of: bash zsh fish",
 	)
 	rootCmd.AddCommand(initCmd)
 }
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Initialize antidot for aliases and env vars to work",
+	Short: "Print shell code to initialize aliases and environment variables based on your current shell, unless -s is passed",
 	Run: func(cmd *cobra.Command, args []string) {
 		shell, err := sh.Get(shellOverride)
 		tui.FatalIfError("", err)
-
-		tui.Print(shell.InitStub())
+		script, err := sh.GetShellScript(shell)
+		tui.FatalIfError("", err)
+		tui.Print(script)
 	},
 }

--- a/internal/shell/bash.go
+++ b/internal/shell/bash.go
@@ -2,19 +2,12 @@ package shell
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/doron-cohen/antidot/internal/utils"
 )
 
 type Bash struct{}
-
-func (b *Bash) EnvFilePath() (string, error) {
-	return utils.AppDirs.GetDataFile("env.sh")
-}
-
-func (b *Bash) AliasFilePath() (string, error) {
-	return utils.AppDirs.GetDataFile("alias.sh")
-}
 
 func (b *Bash) FormatAlias(alias, command string) string {
 	return fmt.Sprintf("alias %s=\"%s\"\n", alias, command)
@@ -25,23 +18,12 @@ func (b *Bash) FormatExport(key, value string) string {
 }
 
 func (b *Bash) InitStub() string {
-	envFilePath, _ := b.EnvFilePath()
-	aliasFilePath, _ := b.AliasFilePath()
-
-	xdgExport := ""
+	builder := strings.Builder{}
+	builder.WriteString("# Put 'eval \"$(antidot init -c bash)\"' (without single quotes) in your bashrc to automatically run this\n")
 	for key, value := range utils.XdgDefaults() {
-		xdgExport += fmt.Sprintf("export %s=\"${%s:-%s}\"\n", key, key, value)
+		builder.WriteString(fmt.Sprintf("export %s=\"${%s:-%s}\"\n", key, key, value))
 	}
-
-	return fmt.Sprintf(`%s
-if [ -f "%s" ]; then source "%s"; fi
-if [ -f "%s" ]; then source "%s"; fi`,
-		xdgExport,
-		envFilePath,
-		envFilePath,
-		aliasFilePath,
-		aliasFilePath,
-	)
+	return builder.String()
 }
 
 func init() {

--- a/internal/shell/bash.go
+++ b/internal/shell/bash.go
@@ -19,7 +19,7 @@ func (b *Bash) FormatExport(key, value string) string {
 
 func (b *Bash) InitStub() string {
 	builder := strings.Builder{}
-	builder.WriteString("# Put 'eval \"$(antidot init -c bash)\"' (without single quotes) in your bashrc to automatically run this\n")
+	builder.WriteString("# Put 'eval \"$(antidot init)\"' (without single quotes) in your bashrc to automatically run this\n")
 	for key, value := range utils.XdgDefaults() {
 		builder.WriteString(fmt.Sprintf("export %s=\"${%s:-%s}\"\n", key, key, value))
 	}

--- a/internal/shell/fish.go
+++ b/internal/shell/fish.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"fmt"
+	"strings"
 	"regexp"
 
 	"github.com/doron-cohen/antidot/internal/utils"
@@ -16,14 +17,6 @@ func unbracketEnvVar(str string) string {
 	return string(bytes)
 }
 
-func (f *Fish) EnvFilePath() (string, error) {
-	return utils.AppDirs.GetDataFile("env.fish")
-}
-
-func (f *Fish) AliasFilePath() (string, error) {
-	return utils.AppDirs.GetDataFile("alias.fish")
-}
-
 func (f *Fish) FormatAlias(alias, command string) string {
 	command = unbracketEnvVar(command)
 	return fmt.Sprintf("alias %s \"%s\"\n", alias, command)
@@ -35,25 +28,14 @@ func (f *Fish) FormatExport(key, value string) string {
 }
 
 func (f *Fish) InitStub() string {
-	envFilePath, _ := f.EnvFilePath()
-	aliasFilePath, _ := f.AliasFilePath()
-
 	format := "set -q %s; or set -x %s=\"%s\"\n"
-	xdgExport := ""
+
+	builder := strings.Builder{}
+	builder.WriteString("# Put 'antidot init | source' (without single quotes) in `fish_config_dir/conf.d/antidot.fish` to automatically run this\n")
 	for key, value := range utils.XdgDefaults() {
-
-		xdgExport += fmt.Sprintf(format, key, key, value)
+		builder.WriteString(fmt.Sprintf(format, key, key, value))
 	}
-
-	return fmt.Sprintf(`%s
-if [ -f "%s" ]; source "%s"; end
-if [ -f "%s" ]; source "%s"; end`,
-		xdgExport,
-		envFilePath,
-		envFilePath,
-		aliasFilePath,
-		aliasFilePath,
-	)
+	return builder.String()
 }
 
 func init() {

--- a/internal/shell/ion.go
+++ b/internal/shell/ion.go
@@ -1,0 +1,31 @@
+package shell
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/doron-cohen/antidot/internal/utils"
+)
+
+type Bash struct{}
+
+func (b *Bash) FormatAlias(alias, command string) string {
+	return fmt.Sprintf("alias %s = \"%s\"\n", alias, command)
+}
+
+func (b *Bash) FormatExport(key, value string) string {
+	return fmt.Sprintf("export %s = \"%s\"\n", key, value)
+}
+
+func (b *Bash) InitStub() string {
+	builder := strings.Builder{}
+	builder.WriteString("# Put 'eval \"$(antidot init -c ion)\"' (without single quotes) in your ionrc to automatically run this\n")
+	for key, value := range utils.XdgDefaults() {
+		builder.WriteString(fmt.Sprintf("export %s = $or(${%s} \"%s\")\n", key, key, value))
+	}
+	return builder.String()
+}
+
+func init() {
+	registerShell("bash", &Bash{})
+}

--- a/internal/shell/ion.go
+++ b/internal/shell/ion.go
@@ -7,19 +7,23 @@ import (
 	"github.com/doron-cohen/antidot/internal/utils"
 )
 
-type Bash struct{}
+type Ion struct{}
 
-func (b *Bash) FormatAlias(alias, command string) string {
+func (b *Ion) FormatAlias(alias, command string) string {
 	return fmt.Sprintf("alias %s = \"%s\"\n", alias, command)
 }
 
-func (b *Bash) FormatExport(key, value string) string {
+func (b *Ion) FormatExport(key, value string) string {
+	// ion uses the variable $HISTFILE itself and it uses a proper location
+	if (key == "HISTFILE") {
+		return ""
+	}
 	return fmt.Sprintf("export %s = \"%s\"\n", key, value)
 }
 
-func (b *Bash) InitStub() string {
+func (b *Ion) InitStub() string {
 	builder := strings.Builder{}
-	builder.WriteString("# Put 'eval \"$(antidot init -c ion)\"' (without single quotes) in your ionrc to automatically run this\n")
+	builder.WriteString("# Put 'eval $(antidot init -c ion)' (without single quotes) in your ionrc to automatically run this\n")
 	for key, value := range utils.XdgDefaults() {
 		builder.WriteString(fmt.Sprintf("export %s = $or(${%s} \"%s\")\n", key, key, value))
 	}
@@ -27,5 +31,5 @@ func (b *Bash) InitStub() string {
 }
 
 func init() {
-	registerShell("bash", &Bash{})
+	registerShell("ion", &Ion{})
 }

--- a/internal/shell/ion.go
+++ b/internal/shell/ion.go
@@ -23,7 +23,7 @@ func (b *Ion) FormatExport(key, value string) string {
 
 func (b *Ion) InitStub() string {
 	builder := strings.Builder{}
-	builder.WriteString("# Put 'eval $(antidot init -c ion)' (without single quotes) in your ionrc to automatically run this\n")
+	builder.WriteString("# Put 'eval $(antidot init)' (without single quotes) in your ionrc to automatically run this\n")
 	for key, value := range utils.XdgDefaults() {
 		builder.WriteString(fmt.Sprintf("export %s = $or(${%s} \"%s\")\n", key, key, value))
 	}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -31,7 +31,11 @@ func Get(shellName string) (Shell, error) {
 
 	shell, ok := SupportedShells[shellName]
 	if !ok {
-		return nil, fmt.Errorf("Shell %s is still not supported.", shellName)
+		var error = strings.Join([]string{"Shell", shellName, "is not supported.\nSupported shells are:\n",}, " ")
+		for name := range SupportedShells {
+			error = strings.Join([]string{error, name}, " ");
+		}
+		return nil, fmt.Errorf(error)
 	}
 
 	return shell, nil

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -39,7 +39,7 @@ func Get(shellName string) (Shell, error) {
 }
 
 func GetShellScript(shell Shell) (string, error) {
-	kvPath, err := utils.AppDirs.GetDataFile("store.json")
+	kvPath, err := utils.AppDirs.GetDataFile("kvstore.json")
 	if err != nil {
 		return "", err
 	}
@@ -48,15 +48,23 @@ func GetShellScript(shell Shell) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if err := kvStore.load(); err != nil {
+		return "", err
+	}
+	if err != nil {
+		return "", err
+	}
 
 	builder := strings.Builder{}
 	builder.WriteString(shell.InitStub())
+	builder.WriteString("\n")
 
 	environment, err := DumpExports(shell, kvStore)
 	if err != nil {
 		return "", err
 	}
 	builder.WriteString(environment)
+	builder.WriteString("\n")
 
 	aliases, err := DumpAliases(shell, kvStore)
 	if err != nil {
@@ -103,7 +111,6 @@ func DumpExports(shell Shell, kvStore *KeyValueStore) (string, error) {
 
 	builder := strings.Builder{}
 	for k, v := range envVars {
-		fmt.Printf("%v: %v", k, v)
 		kvLine := shell.FormatExport(k, v)
 		builder.WriteString(kvLine)
 	}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -32,10 +32,7 @@ func Get(shellName string) (Shell, error) {
 		errorBuilder.WriteString("Shell ")
 		errorBuilder.WriteString(shellName)
 		errorBuilder.WriteString("is not supported.\nSupported shells are:\n")
-		for name := range SupportedShells {
-			errorBuilder.WriteString(" ")
-			errorBuilder.WriteString(name)
-		}
+		errorBuilder.WriteString(ListShells())
 		return nil, fmt.Errorf(errorBuilder.String())
 	}
 

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -79,6 +79,15 @@ func GetShellScript(shell Shell) (string, error) {
 	return builder.String(), nil
 }
 
+func ListShells() string {
+	builder := strings.Builder{}
+	for name, _ := range SupportedShells {
+		builder.WriteString(" ")
+		builder.WriteString(name)
+	}
+	return builder.String()
+}
+
 func detectShell() string {
 	shellPath := os.Getenv("SHELL")
 	if shellPath == "" {


### PR DESCRIPTION
Resolves #164 - also ensures that the variable $HISTFILE (from bash) is *not* set as `ion` sets this variable itself.

This is unrelated to the pull request, but using antidot might be the most cross-platform way to set environment variables now (except `~/.pam_environment` which is deprecated). It's definitely the cross-platform way to set aliases :P