### PR TITLE
Do not check if dotfile name begins with a dot

### DIFF
--- a/internal/dotfile/detect.go
+++ b/internal/dotfile/detect.go
@@ -2,16 +2,11 @@ package dotfile
 
 import (
 	"io/ioutil"
-	"strings"
 )
 
 type Dotfile struct {
 	Name  string
 	IsDir bool `mapstructure:"is_dir"`
-}
-
-func isDotfile(filename string) bool {
-	return filename != "." && strings.HasPrefix(filename, ".")
 }
 
 func Detect(dir string) ([]Dotfile, error) {
@@ -24,13 +19,11 @@ func Detect(dir string) ([]Dotfile, error) {
 	found := make([]Dotfile, 0, len(files))
 	for _, fileInfo := range files {
 		filename := fileInfo.Name()
-		if isDotfile(filename) {
-			dotfile := Dotfile{
-				Name:  filename,
-				IsDir: fileInfo.IsDir(),
-			}
-			found = append(found, dotfile)
+		dotfile := Dotfile{
+			Name:  filename,
+			IsDir: fileInfo.IsDir(),
 		}
+		found = append(found, dotfile)
 	}
 
 	return found, nil


### PR DESCRIPTION
Some applications create a directory in `$HOME` that does not begin with a dot. For example, `perl5` and `go`. With this change, antidot will check for a match for `dotfile: name:` regardless of if it begins with a dot or not.