### PR TITLE
Change standard location of bash history file

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -108,10 +108,10 @@ rules:
     actions:
       - type: migrate
         source: ${HOME}/.bash_history
-        dest: ${XDG_CACHE_HOME}/bash/history
+        dest: ${XDG_DATA_HOME}/bash/history
       - type: export
         key: HISTFILE
-        value: ${XDG_CACHE_HOME}/bash/history
+        value: ${XDG_DATA_HOME}/bash/history
 
   - name: cargo_home
     description: Rust Cargo home dir


### PR DESCRIPTION
This file records Bash command history and can't be automatically recovered like cache files.. So it's better to place it under XDG_DATA_HOME rather than XDG_CACHE_HOME.