### PR TITLE
Add JULIAUP_DEPOT_PATH support to Julia rule

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -1132,6 +1132,9 @@ rules:
       - type: export
         key: JULIA_DEPOT_PATH
         value: ${XDG_DATA_HOME}/julia:${JULIA_DEPOT_PATH}
+      - type: export
+        key: JULIAUP_DEPOT_PATH
+        value: ${XDG_DATA_HOME}/julia:${JULIAUP_DEPOT_PATH}
 
   - name: solargraph
     dotfile:

--- a/rules.yaml
+++ b/rules.yaml
@@ -1126,15 +1126,15 @@ rules:
       name: .julia
       is_dir: true
     actions:
-      - type: migrate
-        source: ${HOME}/.julia
-        dest: ${XDG_DATA_HOME}/julia
       - type: export
         key: JULIA_DEPOT_PATH
         value: ${XDG_DATA_HOME}/julia:${JULIA_DEPOT_PATH}
       - type: export
         key: JULIAUP_DEPOT_PATH
         value: ${XDG_DATA_HOME}/julia:${JULIAUP_DEPOT_PATH}
+      - type: migrate
+        source: ${HOME}/.julia
+        dest: ${XDG_DATA_HOME}/julia
 
   - name: solargraph
     dotfile:


### PR DESCRIPTION
## Summary

This PR fixes issue #271 by adding support for the `JULIAUP_DEPOT_PATH` environment variable to the Julia rule in `rules.yaml`.

## Changes

- Added `JULIAUP_DEPOT_PATH` export to the Julia rule
- The variable is set to `${XDG_DATA_HOME}/julia:${JULIAUP_DEPOT_PATH}` to match the pattern used for `JULIA_DEPOT_PATH`

## Issue

Fixes #271 - `JULIAUP_DEPOT_PATH` needs to be set before moving `.julia`

## Testing

The change ensures that both `JULIA_DEPOT_PATH` and `JULIAUP_DEPOT_PATH` are properly set when migrating Julia configuration files, preventing issues when moving the `.julia` directory out of the home directory.